### PR TITLE
配当落ち前日の米国株を自動ツイートする

### DIFF
--- a/lib/tasks/tweet_task.rake
+++ b/lib/tasks/tweet_task.rake
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+namespace :tweet do
+  desc "権利落ち前日の米国株を配信する"
+  task :ex_dividend_previous_date do
+    tomorrow = Time.at(1.day.since).strftime("%Y-%m-%d")
+    dividends = Client::Fmp.get_dividend_calendar(from: tomorrow, to: tomorrow)
+
+    symbols_text = dividends.map { |dividend| "$#{dividend[:symbol]}" }.sort.join(" ")
+
+    tweet_text = <<~TWEET
+      明日が配当落ち日の米国株は「#{dividends.count}件」です。
+      #{symbols_text}
+    TWEET
+    Client::TwitterWrapper.tweet(tweet_text)
+  end
+end

--- a/lib/tasks/tweet_task.rake
+++ b/lib/tasks/tweet_task.rake
@@ -9,7 +9,7 @@ namespace :tweet do
     symbols_text = dividends.map { |dividend| "$#{dividend[:symbol]}" }.sort.join(" ")
 
     tweet_text = <<~TWEET
-      明日が配当落ち日の米国株は「#{dividends.count}件」です。
+      今日までの購入で配当金が受け取れる米国株は「#{dividends.count}件」です (配当落ち前日)
       #{symbols_text}
     TWEET
     Client::TwitterWrapper.tweet(tweet_text)


### PR DESCRIPTION


>![PixelSnap 2021-07-06 at 23 45 27@2x](https://user-images.githubusercontent.com/53972292/124620215-3df6dc00-deb4-11eb-8e5a-3745efa66363.png)
https://twitter.com/dividend_portal/status/1412422341586571265