### PR TITLE
配当カレンダーAPIレスポンスに dividend = nil なことがある(!?)ので対応

### DIFF
--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -28,11 +28,13 @@ module Tweet
   end
 
   def self.new_dividend_of_dividend_aristocrats
-    report_queue = ReportQueueOfDividendAristocratsDividend.dequeue
-    return unless report_queue
+    ActiveRecord::Base.transaction do
+      report_queue = ReportQueueOfDividendAristocratsDividend.dequeue
+      return unless report_queue
 
-    content = Tweet::Content::DividendReport.new
-    text, image = content.new_dividend_of_dividend_aristocrats(report_queue.dividend.company)
-    Client.tweet_with_image(text, image)
+      content = Tweet::Content::DividendReport.new
+      text, image = content.new_dividend_of_dividend_aristocrats(report_queue.dividend.company)
+      Client.tweet_with_image(text, image)
+    end
   end
 end

--- a/app/models/tweet/content/dividend_report.rb
+++ b/app/models/tweet/content/dividend_report.rb
@@ -78,7 +78,8 @@ module Tweet
       end
 
       def sum_dividend_to_hash(annualized_dividend_hash, dividend_hash)
-        big_decimal = to_bd(annualized_dividend_hash[:annualized_dividend]) + to_bd(dividend_hash[:dividend])
+        dividend = dividend_hash[:dividend] || dividend_hash[:adjusted_dividend]
+        big_decimal = to_bd(annualized_dividend_hash[:annualized_dividend]) + to_bd(dividend)
         {
           annualized_dividend: big_decimal.to_f,
           dividend_count: annualized_dividend_hash[:dividend_count] += 1,

--- a/spec/models/tweet/content/dividend_report_spec.rb
+++ b/spec/models/tweet/content/dividend_report_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Tweet::Content::DividendReport, type: :model do
     end
   end
 
-  describe "#calculate_result_of_dividend_increase" do
+  describe "#calculate_changed_dividend_and_its_rate_from_dividends" do
     let!(:today) { Date.today }
     let!(:base) do
       { ex_dividend_on: today.strftime("%Y-%m-%d"), records_on: today.tomorrow.strftime("%Y-%m-%d"),
@@ -64,6 +64,21 @@ RSpec.describe Tweet::Content::DividendReport, type: :model do
         annualized_dividend: 0.4,
         changed_dividend: 0.36,
         changed_dividend_rate: 9,
+      }
+      expect(actual).to eq expected
+    end
+
+    it "配当情報の dividend がないエッジパターン" do
+      dividends = [
+        base,
+        base.merge(ex_dividend_on: today.months_ago(3).strftime("%Y-%m-%d"), dividend: nil, adjusted_dividend: 0.1),
+        base.merge(ex_dividend_on: today.years_ago(1).strftime("%Y-%m-%d"), dividend: 0.1),
+      ]
+      actual = Tweet::Content::DividendReport.new.calculate_changed_dividend_and_its_rate_from_dividends(dividends)
+      expected = {
+        annualized_dividend: 0.2,
+        changed_dividend: 0.1,
+        changed_dividend_rate: 1,
       }
       expect(actual).to eq expected
     end


### PR DESCRIPTION
ついでに https://github.com/yoshikouki/dividend-portal/issues/69 「レポートキューのツイートに失敗してもキューが削除されてしまう不具合」についても対応しといた