### PR TITLE
株式分割を実施したことがない企業に対応

### DIFF
--- a/app/models/dividend/api/converter.rb
+++ b/app/models/dividend/api/converter.rb
@@ -62,12 +62,12 @@ class Dividend
 
       def self.calculate_total_split_number(historical_stock_splits)
         total_split_number = 1
-        stock_splits = historical_stock_splits.map do |split|
+        stock_splits = historical_stock_splits&.map do |split|
           split_date = Date.parse(split[:date])
           total_split_number *= split[:numerator]
           [split_date, total_split_number]
         end
-        stock_splits.to_h
+        stock_splits&.to_h
       end
 
       # total_split_number_by_span の配列は、最新情報を先頭に時系昇順で並んでいる想定 (必要があれば改修)
@@ -96,6 +96,8 @@ class Dividend
         private
 
         def total_stock_split_number(total_split_number_by_span, ex_dividend_date)
+          return 1 unless total_split_number_by_span
+
           # 現在から権利落ち日まで間の最も古い株式分割
           oldest_stock_splits = total_split_number_by_span.keys.reverse.find { |split_date| split_date.after?(ex_dividend_date) }
           # 株式分割がなければ合計株式分割数は 1


### PR DESCRIPTION
```
2021-09-23T11:00:21.892701+00:00 app[api]: Starting process with command `bin/rails tweet:new_dividend_of_dividend_aristocrats` by user scheduler@addons.heroku.com
2021-09-23T11:00:26.731802+00:00 heroku[scheduler.1950]: Starting process with command `bin/rails tweet:new_dividend_of_dividend_aristocrats`
2021-09-23T11:00:27.462718+00:00 heroku[scheduler.1950]: State changed from starting to up
2021-09-23T11:00:32.374690+00:00 app[scheduler.1950]: rails aborted!
2021-09-23T11:00:32.375477+00:00 app[scheduler.1950]: NoMethodError: undefined method `map' for nil:NilClass
2021-09-23T11:00:32.375968+00:00 app[scheduler.1950]: /app/app/models/dividend/api/converter.rb:65:in `calculate_total_split_number'
2021-09-23T11:00:32.375968+00:00 app[scheduler.1950]: /app/app/models/dividend/api/converter.rb:59:in `recalculate_adjusted_dividend'
2021-09-23T11:00:32.375969+00:00 app[scheduler.1950]: /app/app/models/dividend/api.rb:36:in `all_adjusted'
2021-09-23T11:00:32.375969+00:00 app[scheduler.1950]: /app/app/models/tweet/content/dividend_report.rb:14:in `new_dividend_of_dividend_aristocrats'
2021-09-23T11:00:32.375970+00:00 app[scheduler.1950]: /app/app/models/tweet.rb:36:in `block in new_dividend_of_dividend_aristocrats'
2021-09-23T11:00:32.375971+00:00 app[scheduler.1950]: /app/vendor/bundle/ruby/3.0.0/gems/activerecord-6.1.4/lib/active_record/connection_adapters/abstract/database_statements.rb:320:in `block in transaction'
2021-09-23T11:00:32.375971+00:00 app[scheduler.1950]: /app/vendor/bundle/ruby/3.0.0/gems/activerecord-6.1.4/lib/active_record/connection_adapters/abstract/transaction.rb:319:in `block in within_new_transaction'
2021-09-23T11:00:32.375971+00:00 app[scheduler.1950]: /app/vendor/bundle/ruby/3.0.0/gems/activesupport-6.1.4/lib/active_support/concurrency/load_interlock_aware_monitor.rb:26:in `block (2 levels) in synchronize'
2021-09-23T11:00:32.375972+00:00 app[scheduler.1950]: /app/vendor/bundle/ruby/3.0.0/gems/activesupport-6.1.4/lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `handle_interrupt'
2021-09-23T11:00:32.375972+00:00 app[scheduler.1950]: /app/vendor/bundle/ruby/3.0.0/gems/activesupport-6.1.4/lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `block in synchronize'
2021-09-23T11:00:32.375973+00:00 app[scheduler.1950]: /app/vendor/bundle/ruby/3.0.0/gems/activesupport-6.1.4/lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `handle_interrupt'
2021-09-23T11:00:32.375973+00:00 app[scheduler.1950]: /app/vendor/bundle/ruby/3.0.0/gems/activesupport-6.1.4/lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `synchronize'
2021-09-23T11:00:32.375973+00:00 app[scheduler.1950]: /app/vendor/bundle/ruby/3.0.0/gems/activerecord-6.1.4/lib/active_record/connection_adapters/abstract/transaction.rb:317:in `within_new_transaction'
2021-09-23T11:00:32.375973+00:00 app[scheduler.1950]: /app/vendor/bundle/ruby/3.0.0/gems/activerecord-6.1.4/lib/active_record/connection_adapters/abstract/database_statements.rb:320:in `transaction'
2021-09-23T11:00:32.375988+00:00 app[scheduler.1950]: /app/vendor/bundle/ruby/3.0.0/gems/activerecord-6.1.4/lib/active_record/transactions.rb:209:in `transaction'
2021-09-23T11:00:32.375988+00:00 app[scheduler.1950]: /app/app/models/tweet.rb:31:in `new_dividend_of_dividend_aristocrats'
2021-09-23T11:00:32.375988+00:00 app[scheduler.1950]: /app/lib/tasks/tweet_task.rake:21:in `block (2 levels) in <main>'
2021-09-23T11:00:32.375989+00:00 app[scheduler.1950]: /app/vendor/bundle/ruby/3.0.0/gems/rake-13.0.6/lib/rake/task.rb:281:in `block in execute'
2021-09-23T11:00:32.375989+00:00 app[scheduler.1950]: /app/vendor/bundle/ruby/3.0.0/gems/rake-13.0.6/lib/rake/task.rb:281:in `each'
2021-09-23T11:00:32.375989+00:00 app[scheduler.1950]: /app/vendor/bundle/ruby/3.0.0/gems/rake-13.0.6/lib/rake/task.rb:281:in `execute'
2021-09-23T11:00:32.375990+00:00 app[scheduler.1950]: /app/vendor/bundle/ruby/3.0.0/gems/rake-13.0.6/lib/rake/task.rb:219:in `block in invoke_with_call_chain'
2021-09-23T11:00:32.375990+00:00 app[scheduler.1950]: /app/vendor/bundle/ruby/3.0.0/gems/rake-13.0.6/lib/rake/task.rb:199:in `synchronize'
2021-09-23T11:00:32.375990+00:00 app[scheduler.1950]: /app/vendor/bundle/ruby/3.0.0/gems/rake-13.0.6/lib/rake/task.rb:199:in `invoke_with_call_chain'
2021-09-23T11:00:32.375990+00:00 app[scheduler.1950]: /app/vendor/bundle/ruby/3.0.0/gems/rake-13.0.6/lib/rake/task.rb:188:in `invoke'
2021-09-23T11:00:32.375991+00:00 app[scheduler.1950]: /app/vendor/bundle/ruby/3.0.0/gems/rake-13.0.6/lib/rake/application.rb:160:in `invoke_task'
2021-09-23T11:00:32.375991+00:00 app[scheduler.1950]: /app/vendor/bundle/ruby/3.0.0/gems/rake-13.0.6/lib/rake/application.rb:116:in `block (2 levels) in top_level'
2021-09-23T11:00:32.375991+00:00 app[scheduler.1950]: /app/vendor/bundle/ruby/3.0.0/gems/rake-13.0.6/lib/rake/application.rb:116:in `each'
2021-09-23T11:00:32.375992+00:00 app[scheduler.1950]: /app/vendor/bundle/ruby/3.0.0/gems/rake-13.0.6/lib/rake/application.rb:116:in `block in top_level'
2021-09-23T11:00:32.375992+00:00 app[scheduler.1950]: /app/vendor/bundle/ruby/3.0.0/gems/rake-13.0.6/lib/rake/application.rb:125:in `run_with_threads'
2021-09-23T11:00:32.375992+00:00 app[scheduler.1950]: /app/vendor/bundle/ruby/3.0.0/gems/rake-13.0.6/lib/rake/application.rb:110:in `top_level'
2021-09-23T11:00:32.375993+00:00 app[scheduler.1950]: /app/vendor/bundle/ruby/3.0.0/gems/railties-6.1.4/lib/rails/commands/rake/rake_command.rb:24:in `block (2 levels) in perform'
2021-09-23T11:00:32.375993+00:00 app[scheduler.1950]: /app/vendor/bundle/ruby/3.0.0/gems/rake-13.0.6/lib/rake/application.rb:186:in `standard_exception_handling'
2021-09-23T11:00:32.375993+00:00 app[scheduler.1950]: /app/vendor/bundle/ruby/3.0.0/gems/railties-6.1.4/lib/rails/commands/rake/rake_command.rb:24:in `block in perform'
2021-09-23T11:00:32.375993+00:00 app[scheduler.1950]: /app/vendor/bundle/ruby/3.0.0/gems/rake-13.0.6/lib/rake/rake_module.rb:59:in `with_application'
2021-09-23T11:00:32.375994+00:00 app[scheduler.1950]: /app/vendor/bundle/ruby/3.0.0/gems/railties-6.1.4/lib/rails/commands/rake/rake_command.rb:18:in `perform'
2021-09-23T11:00:32.375994+00:00 app[scheduler.1950]: /app/vendor/bundle/ruby/3.0.0/gems/railties-6.1.4/lib/rails/command.rb:50:in `invoke'
2021-09-23T11:00:32.375994+00:00 app[scheduler.1950]: /app/vendor/bundle/ruby/3.0.0/gems/railties-6.1.4/lib/rails/commands.rb:18:in `<main>'
2021-09-23T11:00:32.375994+00:00 app[scheduler.1950]: /app/vendor/bundle/ruby/3.0.0/gems/bootsnap-1.7.5/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `require'
2021-09-23T11:00:32.375998+00:00 app[scheduler.1950]: /app/vendor/bundle/ruby/3.0.0/gems/bootsnap-1.7.5/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `block in require_with_bootsnap_lfi'
2021-09-23T11:00:32.375999+00:00 app[scheduler.1950]: /app/vendor/bundle/ruby/3.0.0/gems/bootsnap-1.7.5/lib/bootsnap/load_path_cache/loaded_features_index.rb:92:in `register'
2021-09-23T11:00:32.375999+00:00 app[scheduler.1950]: /app/vendor/bundle/ruby/3.0.0/gems/bootsnap-1.7.5/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `require_with_bootsnap_lfi'
2021-09-23T11:00:32.375999+00:00 app[scheduler.1950]: /app/vendor/bundle/ruby/3.0.0/gems/bootsnap-1.7.5/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:31:in `require'
2021-09-23T11:00:32.375999+00:00 app[scheduler.1950]: Tasks: TOP => tweet:new_dividend_of_dividend_aristocrats
2021-09-23T11:00:32.376012+00:00 app[scheduler.1950]: (See full trace by running task with --trace)
2021-09-23T11:00:32.519194+00:00 heroku[scheduler.1950]: Process exited with status 1
2021-09-23T11:00:32.739484+00:00 heroku[scheduler.1950]: State changed from up to complete

```