### PR TITLE
週足値下がりランキングの配信は土曜日だけ実行する

### DIFF
--- a/lib/tasks/tweet_task.rake
+++ b/lib/tasks/tweet_task.rake
@@ -23,6 +23,6 @@ namespace :tweet do
 
   desc "配当貴族の週足値下がりランキングを配信する"
   task ranking_of_weekly_price_drop_rate: :environment do
-    Tweet.new.ranking_of_weekly_price_drop_rate
+    Tweet.new.ranking_of_weekly_price_drop_rate if Date.current.saturday?
   end
 end


### PR DESCRIPTION
heroku の cron では毎週の設定がなく、毎日で設定したため