### PR TITLE
週足値下がりランキングの文面が長すぎてエラーになっていたので修正

### DIFF
--- a/app/views/tweets/ranking_of_weekly_price_drop_rate.text.erb
+++ b/app/views/tweets/ranking_of_weekly_price_drop_rate.text.erb
@@ -1,7 +1,7 @@
-【配当貴族の週足値下がりランキング <%= @reference_date.strftime("%Y-%m-%d") %> #米国株】
+【今週の値下がりランキング #配当貴族 #米国株】
 
 <% @ranking.each.with_index(1) do |price, n| %>
-<%= n %>. $<%= price.symbol %> (変動率 <%= number_to_percentage(price.change_percent, precision: 2) %><%= ", 配当利回り #{number_to_percentage(price.dividend_yield, precision: 2)}" if price.dividend_yield %>)
+<%= n %>. $<%= price.symbol %> (<%= number_to_percentage(price.change_percent, precision: 1) %><%= ", 配当利回 #{number_to_percentage(price.dividend_yield, precision: 1)}" if price.dividend_yield %>)
 <% end %>
 
-↓ 今週最も値下がりした銘柄の週足ラインチャート
+📈最下位の年間チャート📉

--- a/lib/tasks/tweet_task.rake
+++ b/lib/tasks/tweet_task.rake
@@ -23,7 +23,7 @@ namespace :tweet do
 
   desc "配当貴族の週足値下がりランキングを配信する"
   task ranking_of_weekly_price_drop_rate: :environment do
-    Tweet.new.ranking_of_weekly_price_drop_rate if Date.current.saturday?
+    Tweet.new.ranking_of_weekly_price_drop_rate if Date.current.sunday?
   end
 
   desc "配当貴族の日足変動率ランキングを配信する"

--- a/spec/models/tweet/content/dividend_aristocrats_spec.rb
+++ b/spec/models/tweet/content/dividend_aristocrats_spec.rb
@@ -35,7 +35,6 @@ describe "Tweet::Content::DividendAristocrats" do
       it "週足値下がりランキングのコンテンツとチャート画像のパスを配列で返す" do
         VCR.use_cassette "models/tweet/content/dividend_aristocrats/ranking_of_weekly_price_drop_rate" do
           text, chart = Tweet::Content::DividendAristocrats.new.ranking_of_weekly_price_drop_rate(reference_date: reference_date)
-          puts text
           expect(text).to eq expected_content
           expect(chart).to be_an_instance_of File
         end

--- a/spec/models/tweet/content/dividend_aristocrats_spec.rb
+++ b/spec/models/tweet/content/dividend_aristocrats_spec.rb
@@ -20,21 +20,22 @@ describe "Tweet::Content::DividendAristocrats" do
     context "正常系" do
       let!(:expected_content) do
         <<~TWEET
-          【配当貴族の週足値下がりランキング 2021-09-04 #米国株】
+          【今週の値下がりランキング #配当貴族 #米国株】
 
-          1. $ABBV (変動率 -6.86%, 配当利回り 4.55%)
-          2. $NUE (変動率 -5.83%, 配当利回り 1.42%)
-          3. $HRL (変動率 -4.55%, 配当利回り 2.26%)
-          4. $PPG (変動率 -4.43%, 配当利回り 1.42%)
-          5. $LEG (変動率 -3.83%, 配当利回り 3.44%)
+          1. $ABBV (-6.9%, 配当利回 4.6%)
+          2. $NUE (-5.8%, 配当利回 1.4%)
+          3. $HRL (-4.5%, 配当利回 2.3%)
+          4. $PPG (-4.4%, 配当利回 1.4%)
+          5. $LEG (-3.8%, 配当利回 3.4%)
 
-          ↓ 今週最も値下がりした銘柄の週足ラインチャート
+          📈最下位の年間チャート📉
         TWEET
       end
 
       it "週足値下がりランキングのコンテンツとチャート画像のパスを配列で返す" do
         VCR.use_cassette "models/tweet/content/dividend_aristocrats/ranking_of_weekly_price_drop_rate" do
           text, chart = Tweet::Content::DividendAristocrats.new.ranking_of_weekly_price_drop_rate(reference_date: reference_date)
+          puts text
           expect(text).to eq expected_content
           expect(chart).to be_an_instance_of File
         end


### PR DESCRIPTION
# イメージ
【今週の値下がりランキング #配当貴族 #米国株】

1. $ABBV (-6.9%, 配当利回 4.6%)
2. $NUE (-5.8%, 配当利回 1.4%)
3. $HRL (-4.5%, 配当利回 2.3%)
4. $PPG (-4.4%, 配当利回 1.4%)
5. $LEG (-3.8%, 配当利回 3.4%)

📈最下位の年間チャート📉
